### PR TITLE
Milestone: support caching for GET endpoints to Question, Answer, Follow Modules :thinking: :running_man:  

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,15 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs/cache-manager": "^2.1.1",
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0",
         "@nestjs/jwt": "^10.1.1",
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/typeorm": "^10.0.0",
         "bcrypt": "^5.1.1",
+        "cache-manager": "^5.3.1",
+        "cache-manager-redis-store": "^2.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "cookie-session": "^2.0.0",
@@ -30,6 +33,7 @@
         "@nestjs/schematics": "^10.0.0",
         "@nestjs/testing": "^10.0.0",
         "@types/bcrypt": "^5.0.0",
+        "@types/cache-manager-redis-store": "^2.0.4",
         "@types/cookie-session": "^2.0.45",
         "@types/express": "^4.17.17",
         "@types/jest": "^29.5.2",
@@ -1494,6 +1498,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@nestjs/cache-manager": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/cache-manager/-/cache-manager-2.1.1.tgz",
+      "integrity": "sha512-oYfRys4Ng0zp2HTUPNjH7gizf4vvG3PQZZ+3yGemb3xrF+p3JxDSK0cDq9NTjHzD5UmhjiyAftB9GkuL+t3r9g==",
+      "peerDependencies": {
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "cache-manager": "<=5",
+        "reflect-metadata": "^0.1.12",
+        "rxjs": "^7.0.0"
+      }
+    },
     "node_modules/@nestjs/cli": {
       "version": "10.1.18",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.1.18.tgz",
@@ -1938,6 +1954,22 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cache-manager": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/cache-manager/-/cache-manager-4.0.6.tgz",
+      "integrity": "sha512-8qL93MF05/xrzFm/LSPtzNEOE1eQF3VwGHAcQEylgp5hDSTe41jtFwbSYAPfyYcVa28y1vYSjIt0c1fLLUiC/Q==",
+      "dev": true
+    },
+    "node_modules/@types/cache-manager-redis-store": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/cache-manager-redis-store/-/cache-manager-redis-store-2.0.4.tgz",
+      "integrity": "sha512-EG4ac1KsUr07uv6N/O0X1OaQBNVKShVUxn+GwJQQpUkTEi4+KJl6yvqfwc4uTPT1+pwfKRgQhCoHQQCd/ObkZQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/cache-manager": "*",
+        "@types/redis": "^2.8.0"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.36",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
@@ -2119,6 +2151,15 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
+    },
+    "node_modules/@types/redis": {
+      "version": "2.8.32",
+      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.32.tgz",
+      "integrity": "sha512-7jkMKxcGq9p242exlbsVzuJb57KqHRhNl4dHoQu2Y5v9bCAbtIXXH0R3HleSQW4CTOqpHIYUW3t6tpUj4BVQ+w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/semver": {
       "version": "7.5.3",
@@ -3196,6 +3237,35 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cache-manager": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-5.3.1.tgz",
+      "integrity": "sha512-9HP6nc1ZqyZgcVEpy5XS2ns9MYE6cPEM6InA1wQhR6M7GviJzLH2NTFYnf3NEfRmLE351NCSkDo2VISX8dlG+w==",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "^10.0.2",
+        "promise-coalesce": "^1.1.1"
+      }
+    },
+    "node_modules/cache-manager-redis-store": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cache-manager-redis-store/-/cache-manager-redis-store-2.0.0.tgz",
+      "integrity": "sha512-bWLWlUg6nCYHiJLCCYxY2MgvwvKnvlWwrbuynrzpjEIhfArD2GC9LtutIHFEPeyGVQN6C+WEw+P3r+BFBwhswg==",
+      "dependencies": {
+        "redis": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 8.3"
+      }
+    },
+    "node_modules/cache-manager/node_modules/lru-cache": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.3.tgz",
+      "integrity": "sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -4018,6 +4088,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
+    },
+    "node_modules/denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -6427,6 +6505,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -7454,6 +7537,14 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "node_modules/promise-coalesce": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/promise-coalesce/-/promise-coalesce-1.1.1.tgz",
+      "integrity": "sha512-k7+VaIwZc5dRfSF6RELqRY1+LCmcCkrnuNV9HzIpA6iwRHKke+j9yb0LBTTHQ2RRgf6AlMl9TntuTzcgV/BZwg==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -7626,6 +7717,48 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/redis": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
+      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+      "dependencies": {
+        "denque": "^1.5.0",
+        "redis-commands": "^1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-redis"
+      }
+    },
+    "node_modules/redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/reflect-metadata": {

--- a/package.json
+++ b/package.json
@@ -20,12 +20,15 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/cache-manager": "^2.1.1",
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/jwt": "^10.1.1",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/typeorm": "^10.0.0",
     "bcrypt": "^5.1.1",
+    "cache-manager": "^5.3.1",
+    "cache-manager-redis-store": "^2.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "cookie-session": "^2.0.0",
@@ -41,6 +44,7 @@
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
     "@types/bcrypt": "^5.0.0",
+    "@types/cache-manager-redis-store": "^2.0.4",
     "@types/cookie-session": "^2.0.45",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",

--- a/src/answer/answer.controller.ts
+++ b/src/answer/answer.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, NotFoundException, Param, Patch, Post, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, NotFoundException, Param, Patch, Post, Query, UseGuards, UseInterceptors } from '@nestjs/common';
 import { AnswerService } from './answer.service';
 import { AuthGuard } from 'src/auth/guards/auth.guard';
 import { CurrentUser } from 'src/auth/decorators/current-user.decorator';
@@ -12,6 +12,7 @@ import { AnswerOwnerGuard } from './guards/answer-owner.guard';
 import { OwnerAnswer } from './decorators/owner-answer.decorator';
 import { AnswerOrQuestionOwnerGuard } from './guards/answer-or-question-owner.guard';
 import { PaginationDto } from './dto/pagination.dto';
+import { CacheInterceptor } from '@nestjs/cache-manager';
 
 @Serialize(AnswerDto)
 @Controller('answer')
@@ -24,6 +25,7 @@ export class AnswerController {
         return await this.answerSerivce.createAnswer(questionId, body, user)
     }
 
+    @UseInterceptors(CacheInterceptor)
     @Get("/")
     async getAnswer(
         @Query() query: QueryAnswernDto,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -38,6 +38,8 @@ config();
   CacheModule.register({
     isGlobal: true,
     store: redisStore,
+    ttl: parseInt(process.env.REDIS_EXPIRE_IN_SECONDS),
+    max: parseInt(process.env.REDIS_MAX_ROWS),
     host: process.env.REDIS_HOST,
     port: process.env.REDIS_PORT
   }),

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,7 +15,8 @@ import { QuestionLikes } from './question/question-likes.entity';
 import { AnswerModule } from './answer/answer.module';
 import { Answer } from './answer/answer.entity';
 import { AnswerLikes } from './answer/answer-likes.entity';
-
+import { CacheModule } from '@nestjs/cache-manager';
+import * as redisStore from 'cache-manager-redis-store'
 config();
 
 @Module({
@@ -34,11 +35,18 @@ config();
     secret: process.env.JWT_SECRET,
     signOptions: { expiresIn: '60s' }
   }),
+  CacheModule.register({
+    isGlobal: true,
+    store: redisStore,
+    host: process.env.REDIS_HOST,
+    port: process.env.REDIS_PORT
+  }),
     AuthModule,
     EmailModule,
     FollowModule,
     QuestionModule,
-    AnswerModule],
+    AnswerModule
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/follow/follow.controller.ts
+++ b/src/follow/follow.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Post, UseGuards, UseInterceptors } from '@nestjs/common';
 import { FollowService } from './follow.service';
 import { Serialize } from 'src/interceptors/serialize.interceptor';
 import { Follow } from './follow.entity';
@@ -6,6 +6,7 @@ import { FollowDto } from './dto/follow.dto';
 import { AuthGuard } from 'src/auth/guards/auth.guard';
 import { CurrentUser } from 'src/auth/decorators/current-user.decorator';
 import { User } from 'src/auth/user.entity';
+import { CacheInterceptor } from '@nestjs/cache-manager';
 
 @Serialize(FollowDto)
 @UseGuards(AuthGuard)
@@ -18,11 +19,13 @@ export class FollowController {
     return this.followService.startUserFollowing(followingId, follower);
   }
 
+  @UseInterceptors(CacheInterceptor)
   @Get('/followers/:id')
   async getUserFollowers(@Param('id') userId: string): Promise<Follow[]> {
     return this.followService.getUserFollowers(userId);
   }
 
+  @UseInterceptors(CacheInterceptor)
   @Get('/following/:id')
   async getUserFollowing(@Param('id') userId: string): Promise<Follow[]> {
     return this.followService.getUserFollowing(userId);

--- a/src/question/question.controller.ts
+++ b/src/question/question.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, NotFoundException, Param, Patch, Post, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, NotFoundException, Param, Patch, Post, Query, UseGuards, UseInterceptors } from '@nestjs/common';
 import { CurrentUser } from 'src/auth/decorators/current-user.decorator';
 import { User } from 'src/auth/user.entity';
 import { QuestionService } from './question.service';
@@ -11,6 +11,7 @@ import { QuestionOwnerGuard } from './guards/question-owner.guard';
 import { OwnerQuestion } from './decorators/owner-question.decorator';
 import { Question } from './question.entity';
 import { PaginationDto } from 'src/answer/dto/pagination.dto';
+import { CacheInterceptor } from '@nestjs/cache-manager';
 
 @Serialize(QuestionDto)
 @Controller('question')
@@ -23,6 +24,7 @@ export class QuestionController {
         return this.questionService.addQuestion(body, user);
     }
 
+    @UseInterceptors(CacheInterceptor)
     @Get("/")
     async getQuestion(@Query() query: QueryQuestionDto, @Query() pagination: PaginationDto) {
         const questions = await this.questionService.getQuestion(query, pagination);

--- a/src/question/question.service.ts
+++ b/src/question/question.service.ts
@@ -35,8 +35,9 @@ export class QuestionService {
 
     async getQuestion(queryQuestion: QueryQuestionDto, pagination?: PaginationDto) {
         const { questionId, title, description, authorId, creationDate } = queryQuestion;
-        const { page, limit } = pagination;
-        const skip = (page - 1) * limit;
+
+        const { page, limit } = pagination || {};
+        const skip = (page - 1) * limit || 0;
 
         const queryBuilder = await this.questionRepository.createQueryBuilder('question').leftJoinAndSelect('question.author', 'author');
 


### PR DESCRIPTION
## Description: :speech_balloon: 
At this pull request the Caching Manager was added with the use of Redis and Database Store, With this change It will fast the response time by caching the redundant used endpoints responses. 

I used Cache-Aside Pattern and for Cache Eviction Strategies I used TTL, Also I Used maximum rows to indicated the maximum numbers of allowed rows at Redis. 

## Done: :white_check_mark: 
- [x] Using `@nestjs/cache-manager` to setup the caching module. 
- [x] Using `cache-manager-redis-store` to setup the redis as the database store for caching.
- [x] Configure the TTL as a Cache Eviction.
- [x] Used `CacheInterceptor` with the cached endpoints' controller.
